### PR TITLE
Support inline declaration of Cloud Build actions

### DIFF
--- a/examples/github-branch/cloudbuild.yml
+++ b/examples/github-branch/cloudbuild.yml
@@ -3,8 +3,9 @@
 steps:
   - id: echo
     name: busybox:$_BUSYBOX_TAG
+    entrypoint: "echo"
     args:
-      - echo "$_MSG"
+      - "$_MSG"
 substitutions:
   # Busybox tag to use
   _BUSYBOX_TAG: '1.35.0'

--- a/examples/github-location/cloudbuild.yml
+++ b/examples/github-location/cloudbuild.yml
@@ -3,8 +3,9 @@
 steps:
   - id: echo
     name: busybox:$_BUSYBOX_TAG
+    entrypoint: "echo"
     args:
-      - echo "$_MSG"
+      - "$_MSG"
 substitutions:
   # Busybox tag to use
   _BUSYBOX_TAG: '1.35.0'

--- a/examples/github-pr/cloudbuild.yml
+++ b/examples/github-pr/cloudbuild.yml
@@ -3,8 +3,9 @@
 steps:
   - id: echo
     name: busybox:$_BUSYBOX_TAG
+    entrypoint: "echo"
     args:
-      - echo "$_MSG"
+      - "$_MSG"
 substitutions:
   # Busybox tag to use
   _BUSYBOX_TAG: '1.35.0'

--- a/examples/github-tag/cloudbuild.yml
+++ b/examples/github-tag/cloudbuild.yml
@@ -3,8 +3,9 @@
 steps:
   - id: echo
     name: busybox:$_BUSYBOX_TAG
+    entrypoint: "echo"
     args:
-      - echo "$_MSG"
+      - "$_MSG"
 substitutions:
   # Busybox tag to use
   _BUSYBOX_TAG: '1.35.0'

--- a/examples/gsr-branch/cloudbuild.yml
+++ b/examples/gsr-branch/cloudbuild.yml
@@ -3,8 +3,9 @@
 steps:
   - id: echo
     name: busybox:$_BUSYBOX_TAG
+    entrypoint: "echo"
     args:
-      - echo "$_MSG"
+      - "$_MSG"
 substitutions:
   # Busybox tag to use
   _BUSYBOX_TAG: '1.35.0'

--- a/examples/gsr-location/cloudbuild.yml
+++ b/examples/gsr-location/cloudbuild.yml
@@ -3,8 +3,9 @@
 steps:
   - id: echo
     name: busybox:$_BUSYBOX_TAG
+    entrypoint: "echo"
     args:
-      - echo "$_MSG"
+      - "$_MSG"
 substitutions:
   # Busybox tag to use
   _BUSYBOX_TAG: '1.35.0'

--- a/examples/gsr-tag/cloudbuild.yml
+++ b/examples/gsr-tag/cloudbuild.yml
@@ -3,8 +3,9 @@
 steps:
   - id: echo
     name: busybox:$_BUSYBOX_TAG
+    entrypoint: "echo"
     args:
-      - echo "$_MSG"
+      - "$_MSG"
 substitutions:
   # Busybox tag to use
   _BUSYBOX_TAG: '1.35.0'

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,110 @@ resource "google_cloudbuild_trigger" "trigger" {
   filename        = var.filename
   location        = var.location
 
+  dynamic "build" {
+    for_each = var.local_filename != null ? [yamldecode(file(var.local_filename))] : []
+
+    content {
+      dynamic "step" {
+        for_each = try(build.value.steps, [])
+
+        content {
+          id               = try(step.value.id, null)
+          name             = try(step.value.name, null)
+          script           = try(step.value.script, null)
+          entrypoint       = try(step.value.entrypoint, null)
+          args             = try(step.value.args, [])
+          env              = try(step.value.env, [])
+          dir              = try(step.value.dir, null)
+          secret_env       = try(step.value.secretEnv, [])
+          timeout          = try(step.value.timeout, null)
+          allow_failure    = try(step.value.allow_failure, null)
+          allow_exit_codes = try(step.value.allow_exit_codes, null)
+          wait_for         = try(step.value.wait_for, null)
+          dynamic "volumes" {
+            for_each = try(step.value.volumes, [])
+
+            content {
+              name = try(volumes.value.name, null)
+              path = try(volumes.value.path, null)
+            }
+          }
+        }
+      }
+
+      dynamic "artifacts" {
+        for_each = try([build.value.artifacts], [])
+
+        content {
+          images = try(artifacts.value.images, [])
+          objects {
+            location = try(artifacts.value.location, null)
+            paths    = try(artifacts.value.paths, null)
+            timing   = try(artifacts.value.timing, null)
+          }
+        }
+      }
+
+      dynamic "secret" {
+        for_each = try([build.value.secret], [])
+
+        content {
+          kms_key_name = try(secret.value.kmsKeyName, null)
+          secret_env   = try(secret.value.secretEnv, {})
+        }
+      }
+
+      dynamic "available_secrets" {
+        for_each = try([build.value.availableSecrets], [])
+
+        content {
+          dynamic "secret_manager" {
+            for_each = try(available_secrets.value.secretManager, [])
+
+            content {
+              version_name = try(secret_manager.value.versionName, null)
+              env          = try(secret_manager.value.env, null)
+            }
+          }
+        }
+      }
+
+      dynamic "options" {
+        for_each = try([build.value.options], [])
+
+        content {
+          source_provenance_hash  = try(options.value.sourceProvenanceHash, null)
+          requested_verify_option = try(options.value.requestedVerifyOption, null)
+          machine_type            = try(options.value.machineType, null)
+          disk_size_gb            = try(options.value.diskSizeGb, null)
+          substitution_option     = try(options.value.substitutionOption, null)
+          dynamic_substitutions   = try(options.value.dynamicSubstitutions, null)
+          log_streaming_option    = try(options.value.logStreamingOption, null)
+          worker_pool             = try(options.value.pool, null)
+          logging                 = try(options.value.logging, null)
+          env                     = try(options.value.env, null)
+          secret_env              = try(options.value.secretEnv, [])
+
+          dynamic "volumes" {
+            for_each = try(options.value.volumes, [])
+
+            content {
+              name = try(volumes.value.name, null)
+              path = try(volumes.value.path, null)
+            }
+          }  
+        }
+      }
+
+      tags            = try(build.value.tags, [])
+      images          = try(build.value.images, [])
+      substitutions   = try(build.value.substitutions, {})
+      queue_ttl       = try(build.value.queueTtl, null)
+      logs_bucket     = try(build.value.logsBucket, null)
+      timeout         = try(build.value.timeout, "600s")
+    }
+  }
+
   # Google Source Repository trigger
   dynamic "trigger_template" {
     for_each = { for k, v in var.trigger_config : k => v if k == "gsr" && v != null }

--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -20,6 +20,7 @@ module "trigger" {
   included_files  = var.included_files
   substitutions   = var.substitutions
   filename        = var.filename
+  local_filename  = var.local_filename
   dir             = var.dir
   invert_regex    = var.invert_regex
   trigger_config = {

--- a/modules/github/variables.tf
+++ b/modules/github/variables.tf
@@ -100,15 +100,20 @@ EOD
 }
 
 variable "filename" {
-  type = string
-  validation {
-    condition     = coalesce(var.filename, "unspecified") != "unspecified"
-    error_message = "The Cloud Build filename must not be empty."
-  }
+  type        = string
   default     = "cloudbuild.yml"
   description = <<-EOD
 The path, relative to repository root, to the Cloud Build YAML file. The default
 configuration will declare the filename 'cloudbuild.yml'.
+EOD
+}
+
+variable "local_filename" {
+  type        = string
+  default     = null
+  description = <<-EOD
+The path, relative to where terraform module are created, to the Cloud Build YAML file. The default
+configuration will left it unspecified.
 EOD
 }
 

--- a/modules/google-source-repo/main.tf
+++ b/modules/google-source-repo/main.tf
@@ -20,6 +20,7 @@ module "trigger" {
   included_files  = var.included_files
   substitutions   = var.substitutions
   filename        = var.filename
+  local_filename  = var.local_filename
   invert_regex    = var.invert_regex
   dir             = var.dir
   trigger_config = {

--- a/modules/google-source-repo/variables.tf
+++ b/modules/google-source-repo/variables.tf
@@ -100,15 +100,20 @@ EOD
 }
 
 variable "filename" {
-  type = string
-  validation {
-    condition     = coalesce(var.filename, "unspecified") != "unspecified"
-    error_message = "The Cloud Build filename must not be empty."
-  }
+  type        = string
   default     = "cloudbuild.yml"
   description = <<-EOD
 The path, relative to repository root, to the Cloud Build YAML file. The default
 configuration will declare the filename 'cloudbuild.yml'.
+EOD
+}
+
+variable "local_filename" {
+  type        = string
+  default     = null
+  description = <<-EOD
+The path, relative to where terraform module are created, to the Cloud Build YAML file. The default
+configuration will left it unspecified.
 EOD
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -100,15 +100,20 @@ EOD
 }
 
 variable "filename" {
-  type = string
-  validation {
-    condition     = coalesce(var.filename, "unspecified") != "unspecified"
-    error_message = "The Cloud Build filename must not be empty."
-  }
+  type        = string
   default     = "cloudbuild.yml"
   description = <<-EOD
 The path, relative to repository root, to the Cloud Build YAML file. The default
 configuration will declare the filename 'cloudbuild.yml'.
+EOD
+}
+
+variable "local_filename" {
+  type        = string
+  default     = null
+  description = <<-EOD
+The path, relative to where terraform module are created, to the Cloud Build YAML file. The default
+configuration will left it unspecified.
 EOD
 }
 


### PR DESCRIPTION
Cloud Build supports declaring a set of actions on a trigger that do not rely on a YAML declaration file contained within the git repository. As a consumer of this module, I want the option to take advantage of this feature.

Thank you @michaelact for your contribution and work on testing this.
